### PR TITLE
Updated cabal file for PVP of req

### DIFF
--- a/discord-rest/discord-rest.cabal
+++ b/discord-rest/discord-rest.cabal
@@ -34,7 +34,7 @@ library
                      , hslogger==1.2.*
                      , http-client==0.5.*
                      , mtl==2.2.*
-                     , req==0.2.*
+                     , req>=0.2.0 && <0.4
                      , stm==2.4.*
                      , text==1.2.*
                      , time>=1.6 && <1.9


### PR DESCRIPTION
Since your cabal file write `req=0.2.*`, stackage cannot update `req-0.2` to `req-0.3` .
see: https://github.com/fpco/stackage/issues/2594

So, I updated your cabal file.

I checked that Discord.hs is can build using `req-3.0` on Travis CI.
see: https://github.com/matsubara0507/Discord.hs/pull/2